### PR TITLE
Automate

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -5,7 +5,7 @@ resource "aws_vpc" "cooknest_vpc" {
 resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.cooknest_vpc.id
   cidr_block              = "10.0.1.0/24"
-  availability_zone       = "eu-west-2a"
+  availability_zone       = var.availability_zone
   map_public_ip_on_launch = false
 }
 

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,15 +1,19 @@
-resource "aws_instance" "CookNest_instance" {
-  ami           = var.ami_id
-  instance_type = var.instance_type
-  key_name      = "cooknest"
-  tags = {
-    Name = "cooknest_instance"
-  }
+resource "aws_vpc" "cooknest_vpc" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.cooknest_vpc.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "eu-west-2a"
+  map_public_ip_on_launch = false
 }
 
 resource "aws_security_group" "cooknest_sec" {
   name        = var.aws_security_group
   description = "zero trust model"
+  vpc_id      = aws_vpc.cooknest_vpc.id
+
 
   ingress {
     from_port   = 22
@@ -38,5 +42,17 @@ resource "aws_security_group" "cooknest_sec" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+resource "aws_instance" "CookNest_instance" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+  subnet_id     = aws_subnet.public.id
+
+  # Use security_group_ids instead of security_groups
+  vpc_security_group_ids = [aws_security_group.cooknest_sec.id]
+
+  tags = {
+    Name = "cooknest_instance"
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,8 +2,12 @@ output "ami_id" {
   value = var.ami_id
 }
 
-output "security" {
+output "allowed_ips" {
   value     = [for i in range(2) : var.allowed_ips[i]]
   sensitive = true
+}
+
+output "availability_zone" {
+  value = var.availability_zone
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,7 +3,7 @@ output "ami_id" {
 }
 
 output "security" {
-  value = [for i in range(2) : var.allowed_ips[i]]
+  value     = [for i in range(2) : var.allowed_ips[i]]
   sensitive = true
 }
 

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.9.8",
-  "serial": 8,
+  "serial": 22,
   "lineage": "ab051ed5-ac3c-74e2-bb92-523302056b89",
   "outputs": {
     "ami_id": {
@@ -34,7 +34,7 @@
           "schema_version": 1,
           "attributes": {
             "ami": "ami-0acc77abdfc7ed5a6",
-            "arn": "arn:aws:ec2:eu-west-2:727646511792:instance/i-0ba26f9e4ef1a684c",
+            "arn": "arn:aws:ec2:eu-west-2:727646511792:instance/i-01e20015fc566a0a9",
             "associate_public_ip_address": false,
             "availability_zone": "eu-west-2a",
             "capacity_reservation_specification": [
@@ -72,15 +72,15 @@
             "host_id": "",
             "host_resource_group_arn": null,
             "iam_instance_profile": "",
-            "id": "i-0ba26f9e4ef1a684c",
+            "id": "i-01e20015fc566a0a9",
             "instance_initiated_shutdown_behavior": "stop",
             "instance_lifecycle": "",
             "instance_market_options": [],
-            "instance_state": "stopped",
+            "instance_state": "running",
             "instance_type": "t2.micro",
             "ipv6_address_count": 0,
             "ipv6_addresses": [],
-            "key_name": "cooknest",
+            "key_name": "",
             "launch_template": [],
             "maintenance_options": [
               {
@@ -102,8 +102,8 @@
             "password_data": "",
             "placement_group": "",
             "placement_partition_number": 0,
-            "primary_network_interface_id": "eni-05d0af85cc686c3d1",
-            "private_dns": "ip-172-31-19-173.eu-west-2.compute.internal",
+            "primary_network_interface_id": "eni-05c0b52141bef0541",
+            "private_dns": "ip-10-0-1-7.eu-west-2.compute.internal",
             "private_dns_name_options": [
               {
                 "enable_resource_name_dns_a_record": false,
@@ -111,7 +111,7 @@
                 "hostname_type": "ip-name"
               }
             ],
-            "private_ip": "172.31.19.173",
+            "private_ip": "10.0.1.7",
             "public_dns": "",
             "public_ip": "",
             "root_block_device": [
@@ -124,18 +124,16 @@
                 "tags": {},
                 "tags_all": {},
                 "throughput": 125,
-                "volume_id": "vol-039e47ec4de8b094e",
+                "volume_id": "vol-0b605f3606cc421b6",
                 "volume_size": 8,
                 "volume_type": "gp3"
               }
             ],
             "secondary_private_ips": [],
-            "security_groups": [
-              "default"
-            ],
+            "security_groups": [],
             "source_dest_check": true,
             "spot_instance_request_id": "",
-            "subnet_id": "subnet-094c66067efb6538e",
+            "subnet_id": "subnet-04108bc3d5c706cc2",
             "tags": {
               "Name": "cooknest_instance"
             },
@@ -149,11 +147,16 @@
             "user_data_replace_on_change": false,
             "volume_tags": null,
             "vpc_security_group_ids": [
-              "sg-058524ec0f1561fec"
+              "sg-09a2b1571cd87c13c"
             ]
           },
           "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9"
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "aws_security_group.cooknest_sec",
+            "aws_subnet.public",
+            "aws_vpc.cooknest_vpc"
+          ]
         }
       ]
     },
@@ -166,7 +169,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:eu-west-2:727646511792:security-group/sg-044e5b52dac046057",
+            "arn": "arn:aws:ec2:eu-west-2:727646511792:security-group/sg-09a2b1571cd87c13c",
             "description": "zero trust model",
             "egress": [
               {
@@ -183,7 +186,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-044e5b52dac046057",
+            "id": "sg-09a2b1571cd87c13c",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -232,13 +235,95 @@
             "name_prefix": "",
             "owner_id": "727646511792",
             "revoke_rules_on_delete": false,
+            "tags": null,
+            "tags_all": {},
+            "timeouts": null,
+            "vpc_id": "vpc-01831e50633f7bb08"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "aws_vpc.cooknest_vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:eu-west-2:727646511792:subnet/subnet-04108bc3d5c706cc2",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-2a",
+            "availability_zone_id": "euw2-az2",
+            "cidr_block": "10.0.1.0/24",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-04108bc3d5c706cc2",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "727646511792",
+            "private_dns_hostname_type_on_launch": "ip-name",
             "tags": {},
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-05975f00453ec2eaa"
+            "vpc_id": "vpc-01831e50633f7bb08"
           },
           "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "aws_vpc.cooknest_vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "cooknest_vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:eu-west-2:727646511792:vpc/vpc-01831e50633f7bb08",
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.0.0.0/16",
+            "default_network_acl_id": "acl-0e4142196b035d54e",
+            "default_route_table_id": "rtb-050545fe88658df8b",
+            "default_security_group_id": "sg-0a6a5c8091b8b90cc",
+            "dhcp_options_id": "dopt-04382115338ae1516",
+            "enable_dns_hostnames": false,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "id": "vpc-01831e50633f7bb08",
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_network_border_group": "",
+            "ipv6_ipam_pool_id": "",
+            "ipv6_netmask_length": 0,
+            "main_route_table_id": "rtb-050545fe88658df8b",
+            "owner_id": "727646511792",
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
         }
       ]
     }

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,14 +1,10 @@
 {
   "version": 4,
   "terraform_version": "1.9.8",
-  "serial": 22,
+  "serial": 23,
   "lineage": "ab051ed5-ac3c-74e2-bb92-523302056b89",
   "outputs": {
-    "ami_id": {
-      "value": "ami-0acc77abdfc7ed5a6",
-      "type": "string"
-    },
-    "security": {
+    "allowed_ips": {
       "value": [
         "86.129.212.192/32",
         "212.69.43.233/32"
@@ -21,6 +17,14 @@
         ]
       ],
       "sensitive": true
+    },
+    "ami_id": {
+      "value": "ami-0acc77abdfc7ed5a6",
+      "type": "string"
+    },
+    "availability_zone": {
+      "value": "eu-west-2a",
+      "type": "string"
     }
   },
   "resources": [
@@ -235,7 +239,7 @@
             "name_prefix": "",
             "owner_id": "727646511792",
             "revoke_rules_on_delete": false,
-            "tags": null,
+            "tags": {},
             "tags_all": {},
             "timeouts": null,
             "vpc_id": "vpc-01831e50633f7bb08"

--- a/terraform/terraform.tfstate.backup
+++ b/terraform/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.9.8",
-  "serial": 18,
+  "serial": 22,
   "lineage": "ab051ed5-ac3c-74e2-bb92-523302056b89",
   "outputs": {
     "ami_id": {
@@ -26,6 +26,142 @@
   "resources": [
     {
       "mode": "managed",
+      "type": "aws_instance",
+      "name": "CookNest_instance",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "ami": "ami-0acc77abdfc7ed5a6",
+            "arn": "arn:aws:ec2:eu-west-2:727646511792:instance/i-01e20015fc566a0a9",
+            "associate_public_ip_address": false,
+            "availability_zone": "eu-west-2a",
+            "capacity_reservation_specification": [
+              {
+                "capacity_reservation_preference": "open",
+                "capacity_reservation_target": []
+              }
+            ],
+            "cpu_core_count": 1,
+            "cpu_options": [
+              {
+                "amd_sev_snp": "",
+                "core_count": 1,
+                "threads_per_core": 1
+              }
+            ],
+            "cpu_threads_per_core": 1,
+            "credit_specification": [
+              {
+                "cpu_credits": "standard"
+              }
+            ],
+            "disable_api_stop": false,
+            "disable_api_termination": false,
+            "ebs_block_device": [],
+            "ebs_optimized": false,
+            "enclave_options": [
+              {
+                "enabled": false
+              }
+            ],
+            "ephemeral_block_device": [],
+            "get_password_data": false,
+            "hibernation": false,
+            "host_id": "",
+            "host_resource_group_arn": null,
+            "iam_instance_profile": "",
+            "id": "i-01e20015fc566a0a9",
+            "instance_initiated_shutdown_behavior": "stop",
+            "instance_lifecycle": "",
+            "instance_market_options": [],
+            "instance_state": "running",
+            "instance_type": "t2.micro",
+            "ipv6_address_count": 0,
+            "ipv6_addresses": [],
+            "key_name": "",
+            "launch_template": [],
+            "maintenance_options": [
+              {
+                "auto_recovery": "default"
+              }
+            ],
+            "metadata_options": [
+              {
+                "http_endpoint": "enabled",
+                "http_protocol_ipv6": "disabled",
+                "http_put_response_hop_limit": 2,
+                "http_tokens": "required",
+                "instance_metadata_tags": "disabled"
+              }
+            ],
+            "monitoring": false,
+            "network_interface": [],
+            "outpost_arn": "",
+            "password_data": "",
+            "placement_group": "",
+            "placement_partition_number": 0,
+            "primary_network_interface_id": "eni-05c0b52141bef0541",
+            "private_dns": "ip-10-0-1-7.eu-west-2.compute.internal",
+            "private_dns_name_options": [
+              {
+                "enable_resource_name_dns_a_record": false,
+                "enable_resource_name_dns_aaaa_record": false,
+                "hostname_type": "ip-name"
+              }
+            ],
+            "private_ip": "10.0.1.7",
+            "public_dns": "",
+            "public_ip": "",
+            "root_block_device": [
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/xvda",
+                "encrypted": false,
+                "iops": 3000,
+                "kms_key_id": "",
+                "tags": {},
+                "tags_all": {},
+                "throughput": 125,
+                "volume_id": "vol-0b605f3606cc421b6",
+                "volume_size": 8,
+                "volume_type": "gp3"
+              }
+            ],
+            "secondary_private_ips": [],
+            "security_groups": [],
+            "source_dest_check": true,
+            "spot_instance_request_id": "",
+            "subnet_id": "subnet-04108bc3d5c706cc2",
+            "tags": {
+              "Name": "cooknest_instance"
+            },
+            "tags_all": {
+              "Name": "cooknest_instance"
+            },
+            "tenancy": "default",
+            "timeouts": null,
+            "user_data": null,
+            "user_data_base64": null,
+            "user_data_replace_on_change": false,
+            "volume_tags": null,
+            "vpc_security_group_ids": [
+              "sg-09a2b1571cd87c13c"
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "aws_security_group.cooknest_sec",
+            "aws_subnet.public",
+            "aws_vpc.cooknest_vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
       "type": "aws_security_group",
       "name": "cooknest_sec",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
@@ -33,7 +169,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:eu-west-2:727646511792:security-group/sg-044e5b52dac046057",
+            "arn": "arn:aws:ec2:eu-west-2:727646511792:security-group/sg-09a2b1571cd87c13c",
             "description": "zero trust model",
             "egress": [
               {
@@ -50,7 +186,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-044e5b52dac046057",
+            "id": "sg-09a2b1571cd87c13c",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -99,13 +235,16 @@
             "name_prefix": "",
             "owner_id": "727646511792",
             "revoke_rules_on_delete": false,
-            "tags": {},
+            "tags": null,
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-05975f00453ec2eaa"
+            "vpc_id": "vpc-01831e50633f7bb08"
           },
           "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "aws_vpc.cooknest_vpc"
+          ]
         }
       ]
     },

--- a/terraform/terraform.tfstate.backup
+++ b/terraform/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.9.8",
-  "serial": 7,
+  "serial": 18,
   "lineage": "ab051ed5-ac3c-74e2-bb92-523302056b89",
   "outputs": {
     "ami_id": {
@@ -19,143 +19,11 @@
           "string",
           "string"
         ]
-      ]
+      ],
+      "sensitive": true
     }
   },
   "resources": [
-    {
-      "mode": "managed",
-      "type": "aws_instance",
-      "name": "CookNest_instance",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 1,
-          "attributes": {
-            "ami": "ami-0acc77abdfc7ed5a6",
-            "arn": "arn:aws:ec2:eu-west-2:727646511792:instance/i-0ba26f9e4ef1a684c",
-            "associate_public_ip_address": false,
-            "availability_zone": "eu-west-2a",
-            "capacity_reservation_specification": [
-              {
-                "capacity_reservation_preference": "open",
-                "capacity_reservation_target": []
-              }
-            ],
-            "cpu_core_count": 1,
-            "cpu_options": [
-              {
-                "amd_sev_snp": "",
-                "core_count": 1,
-                "threads_per_core": 1
-              }
-            ],
-            "cpu_threads_per_core": 1,
-            "credit_specification": [
-              {
-                "cpu_credits": "standard"
-              }
-            ],
-            "disable_api_stop": false,
-            "disable_api_termination": false,
-            "ebs_block_device": [],
-            "ebs_optimized": false,
-            "enclave_options": [
-              {
-                "enabled": false
-              }
-            ],
-            "ephemeral_block_device": [],
-            "get_password_data": false,
-            "hibernation": false,
-            "host_id": "",
-            "host_resource_group_arn": null,
-            "iam_instance_profile": "",
-            "id": "i-0ba26f9e4ef1a684c",
-            "instance_initiated_shutdown_behavior": "stop",
-            "instance_lifecycle": "",
-            "instance_market_options": [],
-            "instance_state": "stopped",
-            "instance_type": "t2.micro",
-            "ipv6_address_count": 0,
-            "ipv6_addresses": [],
-            "key_name": "cooknest",
-            "launch_template": [],
-            "maintenance_options": [
-              {
-                "auto_recovery": "default"
-              }
-            ],
-            "metadata_options": [
-              {
-                "http_endpoint": "enabled",
-                "http_protocol_ipv6": "disabled",
-                "http_put_response_hop_limit": 2,
-                "http_tokens": "required",
-                "instance_metadata_tags": "disabled"
-              }
-            ],
-            "monitoring": false,
-            "network_interface": [],
-            "outpost_arn": "",
-            "password_data": "",
-            "placement_group": "",
-            "placement_partition_number": 0,
-            "primary_network_interface_id": "eni-05d0af85cc686c3d1",
-            "private_dns": "ip-172-31-19-173.eu-west-2.compute.internal",
-            "private_dns_name_options": [
-              {
-                "enable_resource_name_dns_a_record": false,
-                "enable_resource_name_dns_aaaa_record": false,
-                "hostname_type": "ip-name"
-              }
-            ],
-            "private_ip": "172.31.19.173",
-            "public_dns": "",
-            "public_ip": "",
-            "root_block_device": [
-              {
-                "delete_on_termination": true,
-                "device_name": "/dev/xvda",
-                "encrypted": false,
-                "iops": 3000,
-                "kms_key_id": "",
-                "tags": {},
-                "tags_all": {},
-                "throughput": 125,
-                "volume_id": "vol-039e47ec4de8b094e",
-                "volume_size": 8,
-                "volume_type": "gp3"
-              }
-            ],
-            "secondary_private_ips": [],
-            "security_groups": [
-              "default"
-            ],
-            "source_dest_check": true,
-            "spot_instance_request_id": "",
-            "subnet_id": "subnet-094c66067efb6538e",
-            "tags": {
-              "Name": "cooknest_instance"
-            },
-            "tags_all": {
-              "Name": "cooknest_instance"
-            },
-            "tenancy": "default",
-            "timeouts": null,
-            "user_data": null,
-            "user_data_base64": null,
-            "user_data_replace_on_change": false,
-            "volume_tags": null,
-            "vpc_security_group_ids": [
-              "sg-058524ec0f1561fec"
-            ]
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9"
-        }
-      ]
-    },
     {
       "mode": "managed",
       "type": "aws_security_group",
@@ -231,13 +99,92 @@
             "name_prefix": "",
             "owner_id": "727646511792",
             "revoke_rules_on_delete": false,
-            "tags": null,
+            "tags": {},
             "tags_all": {},
             "timeouts": null,
             "vpc_id": "vpc-05975f00453ec2eaa"
           },
           "sensitive_attributes": [],
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:eu-west-2:727646511792:subnet/subnet-04108bc3d5c706cc2",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-2a",
+            "availability_zone_id": "euw2-az2",
+            "cidr_block": "10.0.1.0/24",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-04108bc3d5c706cc2",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "727646511792",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null,
+            "vpc_id": "vpc-01831e50633f7bb08"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "aws_vpc.cooknest_vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "cooknest_vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:eu-west-2:727646511792:vpc/vpc-01831e50633f7bb08",
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.0.0.0/16",
+            "default_network_acl_id": "acl-0e4142196b035d54e",
+            "default_route_table_id": "rtb-050545fe88658df8b",
+            "default_security_group_id": "sg-0a6a5c8091b8b90cc",
+            "dhcp_options_id": "dopt-04382115338ae1516",
+            "enable_dns_hostnames": false,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "id": "vpc-01831e50633f7bb08",
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_network_border_group": "",
+            "ipv6_ipam_pool_id": "",
+            "ipv6_netmask_length": 0,
+            "main_route_table_id": "rtb-050545fe88658df8b",
+            "owner_id": "727646511792",
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
         }
       ]
     }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -24,5 +24,5 @@ variable "allowed_ips" {
 
 variable "availability_zone" {
   default     = "eu-west-2a"
-  description = "Where is our subnets going to live amongst our the AZ's"
+  description = "Where is our subnets going to live amongst the AZ's"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,3 +22,7 @@ variable "allowed_ips" {
   ]
 }
 
+variable "availability_zone" {
+  default     = "eu-west-2a"
+  description = "Where is our subnets going to live amongst our the AZ's"
+}


### PR DESCRIPTION
The configuration in these files:

- Creates VPCs within our infrastructure.
- Within these VPCs, there are subnets — one of which is public, where we will host our 
   backend (including the APIs and everything related to it).
- The security groups are defined for the VPCs rather than for the individual EC2 instances. 
-  However, despite this, the VPCs themselves can't be directly secured. They are essentially 
   partitioning a small section of the network/internet to host our backend.
- While the VPC has security groups in place, the EC2 instances are the ones that are truly 
   secured, even if they reside in a public subnet.